### PR TITLE
Bugfix/wrong winner displayed

### DIFF
--- a/src/main/java/com/toptrumps/core/engine/Game.java
+++ b/src/main/java/com/toptrumps/core/engine/Game.java
@@ -101,17 +101,12 @@ public class Game {
             // TODO: Revisit this to avoid another loop
             players.forEach(Player::removeTopCard);
 
-            //collect any defeated players and remove them from the game
-            ArrayList<Player> removedPlayers = (ArrayList<Player>) players.stream().filter(p -> p.getDeck().isEmpty()).collect(toList());
-            players.removeAll(removedPlayers);
-            numberOfPlayers = players.size();
-
             if (winners.size() == 1) {
                 // There's a winner
                 activePlayer.setActive(false);
                 Player winner = winners.get(0);
                 winner.setActive(true);
-                outcome = new RoundOutcome(VICTORY, winner, removedPlayers);
+                outcome = new RoundOutcome(VICTORY, winner);
                 // Collect all player's cards
                 List<Card> communalPile = dealer.dealCommunalPile();
                 roundCards.addAll(communalPile);
@@ -119,9 +114,15 @@ public class Game {
                 activePlayer = winner;
             } else {
                 // Draw
-                outcome = new RoundOutcome(DRAW, winners, removedPlayers);
+                outcome = new RoundOutcome(DRAW, winners);
                 dealer.putCardsOnCommunalPile(roundCards);
             }
+
+            //collect any defeated players and remove them from the game
+            ArrayList<Player> removedPlayers = (ArrayList<Player>) players.stream().filter(p -> p.getDeck().isEmpty()).collect(toList());
+            outcome.setRemovedPlayers(removedPlayers);
+            players.removeAll(removedPlayers);
+            numberOfPlayers = players.size();
 
             listener.onRoundEnd(outcome);
         }

--- a/src/main/java/com/toptrumps/core/engine/RoundOutcome.java
+++ b/src/main/java/com/toptrumps/core/engine/RoundOutcome.java
@@ -15,19 +15,18 @@ public class RoundOutcome {
     private ArrayList<Player> draws;
     private ArrayList<Player> removedPlayers;
 
-    private RoundOutcome(Result result, Player winner, ArrayList<Player> draws, ArrayList<Player> removedPlayers) {
+    private RoundOutcome(Result result, Player winner, ArrayList<Player> draws) {
         this.result = result;
         this.winner = winner;
         this.draws = draws;
-        this.removedPlayers = removedPlayers;
     }
 
-    public RoundOutcome(Result result, Player winner, ArrayList<Player> removedPlayers) {
-        this(result, winner, null, removedPlayers);
+    public RoundOutcome(Result result, Player winner) {
+        this(result, winner, null);
     }
 
-    public RoundOutcome(Result result, ArrayList<Player> draws, ArrayList<Player> removedPlayers) {
-        this(result, null, draws, removedPlayers);
+    public RoundOutcome(Result result, ArrayList<Player> draws) {
+        this(result, null, draws);
     }
 
     public Result getResult() {
@@ -44,6 +43,10 @@ public class RoundOutcome {
 
     public ArrayList<Player> getRemovedPlayers(){
         return removedPlayers;
+    }
+
+    public void setRemovedPlayers(ArrayList<Player> removedPlayers){
+        this.removedPlayers = removedPlayers;
     }
 
 }


### PR DESCRIPTION
Issue #43 where wrong winner was being displayed
-In game the cards from a round are collected up before being distributed to the winner
-Previously the game was removing players between these 2 steps
-It was incorrectly removing players who had won the round but had not yet been handed their winning cards
-The remove player steps have been moved to after the point where cards have been redistributed to the winner - so it now removes the right players
-Had to create new setRemovedPlayers() method in RoundOutcome as this could no longer be passed through the constructor