### PR TITLE
Bugfix/winner incorrectly removed

### DIFF
--- a/src/main/java/com/toptrumps/core/engine/Game.java
+++ b/src/main/java/com/toptrumps/core/engine/Game.java
@@ -97,6 +97,10 @@ public class Game {
         if (players.size() == 1) {
             outcome = new RoundOutcome(GAME_OVER);
         } else if (winners.size() == 1) {
+            if(removedPlayers.contains(winners.get(0))){
+                removedPlayers.remove(winners.get(0));
+            }
+
             Player winner = winners.get(0);
             winner.setActive(true);
             outcome = new RoundOutcome(VICTORY, winner, removedPlayers);

--- a/src/main/java/com/toptrumps/core/engine/Game.java
+++ b/src/main/java/com/toptrumps/core/engine/Game.java
@@ -97,12 +97,13 @@ public class Game {
         if (players.size() == 1) {
             outcome = new RoundOutcome(GAME_OVER);
         } else if (winners.size() == 1) {
-            if(removedPlayers.contains(winners.get(0))){
-                removedPlayers.remove(winners.get(0));
-            }
-
             Player winner = winners.get(0);
             winner.setActive(true);
+
+            if(removedPlayers.contains(winner)){
+                removedPlayers.remove(winner);
+            }
+            
             outcome = new RoundOutcome(VICTORY, winner, removedPlayers);
         } else {
             outcome = new RoundOutcome(DRAW, winners, removedPlayers);


### PR DESCRIPTION
-There is a case after all top cards have been removed that the round winner is left with 0 cards
-The game considers this player a losing player and adds them to the removed players list - this occurs before they receive the cards for winning the round
-Added if statement to check if this player has been accidentally added to the removed players list - if this is the case then we remove them from this list