### PR TITLE
Improved AI selection of cards

### DIFF
--- a/src/main/java/com/toptrumps/core/card/Card.java
+++ b/src/main/java/com/toptrumps/core/card/Card.java
@@ -11,11 +11,11 @@ public class Card {
 
     private String name;
     private ArrayList<Attribute> attributes;
+    private ArrayList<Attribute> highestAttributes;
 
     /**
      * Lazily filter the highest attribute and store it as a final member variable
      */
-    final private Supplier<Attribute> highestAttribute = () -> Collections.max(attributes);
 
     public Card() {
         // Jackson deserialization
@@ -24,6 +24,8 @@ public class Card {
     public Card(String name, ArrayList<Attribute> attributes) {
         this.name = name;
         this.attributes = attributes;
+        highestAttributes = new ArrayList<>();
+        findHighestAttributes();
     }
 
     public String getName() {
@@ -37,14 +39,23 @@ public class Card {
                 .findFirst()
                 .orElse(null);
     }
+    private void findHighestAttributes() {
+        Supplier<Attribute> highestAttribute = () -> Collections.max(attributes);
+
+        for (Attribute a : attributes){
+            if (a.getValue() == highestAttribute.get().getValue()){
+                highestAttributes.add(a);
+            }
+        }
+    }
 
     public ArrayList<Attribute> getAttributes() {
         return attributes;
     }
 
     @JsonIgnore
-    public Attribute getHighestAttribute() {
-        return this.highestAttribute.get();
+    public ArrayList<Attribute> getHighestAttributes() {
+        return highestAttributes;
     }
 
     @Override

--- a/src/main/java/com/toptrumps/core/player/AIPlayer.java
+++ b/src/main/java/com/toptrumps/core/player/AIPlayer.java
@@ -4,6 +4,9 @@ import com.toptrumps.core.card.Attribute;
 import com.toptrumps.core.card.Card;
 import com.toptrumps.online.api.request.PlayerState;
 
+import java.util.ArrayList;
+import java.util.Random;
+
 /**
  * Represents an AI player in the game.
  * There can be up to 4 AI players.
@@ -23,9 +26,11 @@ public class AIPlayer extends Player {
 
     public Attribute selectAttribute() {
         Card topCard = getTopCard();
-        Attribute highestAttribute = topCard.getHighestAttribute();
-        this.setSelectedAttribute(highestAttribute);
-        return highestAttribute;
+        ArrayList<Attribute> highestAttributes = topCard.getHighestAttributes();
+        Random rand = new Random();
+        Attribute selectedHighestAttribute = highestAttributes.get(rand.nextInt((highestAttributes.size())));
+        this.setSelectedAttribute(selectedHighestAttribute);
+        return  selectedHighestAttribute;
     }
 
 }


### PR DESCRIPTION
Issue #58 

So, I may not make myself too popular with this one haha, but changed the AI Player's behaviour to choose between all the available best attributes it can play. As previously discussed, this tackles the edge case where there were 2+ best attributes available the AI would always choose the first occurance. 

When cards are created, the highest attributes are stored in the ArrayList `highestAttributes`. When the AI comes to choose, it picks a random index from this array to choose an attribute. 

As you can see below, it works as intended. 

![image](https://user-images.githubusercontent.com/20328038/74102453-83866c80-4b3b-11ea-82c0-1be1c769e05d.png)
