### PR TITLE
Fix selected AIPlayer mapping

### DIFF
--- a/src/main/java/com/toptrumps/online/api/TopTrumpsRESTAPI.java
+++ b/src/main/java/com/toptrumps/online/api/TopTrumpsRESTAPI.java
@@ -83,9 +83,9 @@ public class TopTrumpsRESTAPI {
     @Path("/api/outcome/ai")
     @Produces(MediaType.APPLICATION_JSON)
     public Outcome getRoundOutcome(PlayerMove aiPlayerMove) {
-        Player aiPlayer = aiPlayerMove.getPlayerState().toPlayer();
+        Player activeAIPlayer = aiPlayerMove.getActivePlayerState().toPlayer();
         List<Player> players = aiPlayerMove.getPlayerStates().stream().map(PlayerState::toPlayer).collect(toList());
-        Attribute selectedAttribute = ((AIPlayer) aiPlayer).selectAttribute();
+        Attribute selectedAttribute = ((AIPlayer) activeAIPlayer).selectAttribute();
         List<Player> winners = gameEngine.getWinners(selectedAttribute, players);
         players.forEach(Player::removeTopCard);
         RoundOutcome roundOutcome = gameEngine.processRoundOutcome(winners, players);

--- a/src/main/java/com/toptrumps/online/api/request/PlayerMove.java
+++ b/src/main/java/com/toptrumps/online/api/request/PlayerMove.java
@@ -30,8 +30,12 @@ public class PlayerMove {
         return activePlayerId;
     }
 
-    public PlayerState getPlayerState() {
-        return playerStates.get(activePlayerId);
+    // TODO: Optimize all filter operations
+    public PlayerState getActivePlayerState() {
+        return playerStates.stream()
+                .filter(p -> p.getId() == activePlayerId)
+                .findFirst()
+                .orElse(null);
     }
 
 }


### PR DESCRIPTION
Previously, the REST API was trying to use the provided ```activePlayerId``` to access an element of ```playerStates``` list. This was obviously a mistake! Now, it filters the list to find the ```PlayerState``` with the correct ID. 