### PR TITLE
Enforce round cards to be shuffled before collected

### DIFF
--- a/src/main/java/com/toptrumps/cli/CommandLineController.java
+++ b/src/main/java/com/toptrumps/cli/CommandLineController.java
@@ -118,7 +118,9 @@ public class CommandLineController {
             List<Player> winners = gameEngine.getWinners(selectedAttribute, players);
             // Retrieve the round cards
             List<Card> winningCards = winners.stream().map(Player::getTopCard).collect(toCollection(ArrayList::new));
-            List<Card> roundCards = players.stream().map(Player::getTopCard).collect(toCollection(ArrayList::new));
+            // Extracts a shuffled list of round cards
+            List<Card> roundCards = gameEngine.getShuffledRoundCards(players);
+
             // Remove the topCard from each player
             players.forEach(Player::removeTopCard);
 
@@ -167,14 +169,6 @@ public class CommandLineController {
         // Invoke the lifecycle method 
         skipPrintAnimation = false;
         onGameOver(activePlayer, roundWinsMap);
-    }
-
-    private void presentStatistics() {
-        Statistics stats = new Statistics();
-        view.showStats(stats);
-        view.showNextRoundMessage();
-        scanner.nextLine();
-        start();
     }
 
     // === LIFECYCLE METHODS ===
@@ -285,6 +279,14 @@ public class CommandLineController {
         // By convention, the human player is always the first element;
         // The ternary operator checks if the human player has been eliminated
         return players.get(0).isAIPlayer() ? null : players.get(0);
+    }
+
+    private void presentStatistics() {
+        Statistics stats = new Statistics();
+        view.showStats(stats);
+        view.showNextRoundMessage();
+        scanner.nextLine();
+        start();
     }
 
 }

--- a/src/main/java/com/toptrumps/core/card/Dealer.java
+++ b/src/main/java/com/toptrumps/core/card/Dealer.java
@@ -4,6 +4,7 @@ import com.toptrumps.cli.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -41,13 +42,24 @@ public class Dealer {
     }
 
     /**
+     * Randomly rearrange the order of the card elements
+     * @param cards list of cards to be shuffled
+     */
+    public void shuffleCards(List<Card> cards) {
+        // Randomly reorder the list of cards
+        Collections.shuffle(cards, new Random());
+    }
+
+    /**
      * Returns shuffled split decks bases on the number of players present in the game.
      *
      * @param numberOfPlayers the number of players present in the game
      * @return a list of shuffled smaller decks (list of cards)
      */
     public ArrayList<ArrayList<Card>> dealCards(int numberOfPlayers) {
-        shuffleCards();
+        shuffleCards(deck);
+        // Logs the shuffled deck if enabled
+        Logger.getInstance().logToFileIfEnabled("Shuffled cards: \n" + printDeck());
         return splitDeck(numberOfPlayers);
     }
 
@@ -65,13 +77,6 @@ public class Dealer {
     }
 
     // === CONVENIENCE METHODS ===
-
-    private void shuffleCards() {
-        // Randomly reorder the list of cards
-        Collections.shuffle(deck, new Random());
-        // Logs the shuffled deck if enabled
-        Logger.getInstance().logToFileIfEnabled("Shuffled cards: \n" + printDeck());
-    }
 
     private ArrayList<ArrayList<Card>> splitDeck(int numberOfSplits) {
         int size = this.deck.size();

--- a/src/main/java/com/toptrumps/core/engine/GameEngine.java
+++ b/src/main/java/com/toptrumps/core/engine/GameEngine.java
@@ -105,6 +105,20 @@ public class GameEngine {
     }
 
     /**
+     * Returns a shuffled list of cards based on the top cards of the round players.
+     *
+     * @param roundPlayers a list of players that participate in a game round
+     * @return a shuffled list of top cards
+     */
+    public List<Card> getShuffledRoundCards(List<Player> roundPlayers) {
+        List<Card> roundCards = roundPlayers.stream()
+                .map(Player::getTopCard)
+                .collect(toCollection(ArrayList::new));
+        dealer.shuffleCards(roundCards);
+        return roundCards;
+    }
+
+    /**
      * Returns the round outcome based on the winners and players of a round.
      * The RoundOutcome result can be VICTORY, DRAW, or GAME_OVER.
      *

--- a/src/test/java/com/toptrumps/core/engine/GameEngineTest.java
+++ b/src/test/java/com/toptrumps/core/engine/GameEngineTest.java
@@ -9,13 +9,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.sun.tools.internal.xjc.reader.Ring.add;
 import static com.toptrumps.core.engine.RoundOutcome.Result.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static java.util.stream.Collectors.toCollection;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
-class CoreEngineTest {
+class GameEngineTest {
 
     private final static String DECK_RESOURCE = "assets/WitcherDeck.txt";
 
@@ -108,6 +109,15 @@ class CoreEngineTest {
         Attribute selectedAttribute = winningAttributes.get(0);
 
         assertEquals(2, gameEngine.getWinners(selectedAttribute, roundPlayers).size());
+    }
+
+    @Test
+    @DisplayName("getShuffledRoundCards should return a shuffled list of top cards")
+    void getShuffledRoundCards_RoundPlayers_ShuffledCardList() {
+        List<Card> roundCards = players.stream().map(Player::getTopCard).collect(toCollection(ArrayList::new));
+        List<Card> intactRoundCards = new ArrayList<>(roundCards);
+        roundCards = gameEngine.getShuffledRoundCards(players);
+        assertNotEquals(intactRoundCards, roundCards);
     }
 
     @Test


### PR DESCRIPTION
According to @Arden488 revision, we are supposed to shuffle the round cards before distributing them to a winner or to the communal pile. This PR takes care of this process for the CLI App.

https://trello.com/c/RJ312nKF