### PR TITLE
Tweak online dynamics and add loader for requests

### DIFF
--- a/src/main/resources/com/toptrumps/online/scripts/GameController.js
+++ b/src/main/resources/com/toptrumps/online/scripts/GameController.js
@@ -225,12 +225,6 @@ const GameController = (($) => {
             view.displayRemovedPlayers(removedPlayerIds);
         }
 
-        // Update deck count for every player
-        const players = model.getPlayers();
-        $.each(players, (i, player) => {
-            view.updateDeckCount(player.id, player.deck.length);
-        });
-
         showRoundOutcome(response);
 
     };
@@ -256,6 +250,12 @@ const GameController = (($) => {
             model.setActivePlayer(response.winner.id);
             view.displayWinnerPlayer(response.winner.id);
         }
+
+        // Update deck count for every player
+        const players = model.getPlayers();
+        $.each(players, (i, player) => {
+            view.updateDeckCount(player.id, player.deck.length);
+        });
 
         await view.delay(timerBase * 2);
 

--- a/src/main/resources/com/toptrumps/online/scripts/StatisticsController.js
+++ b/src/main/resources/com/toptrumps/online/scripts/StatisticsController.js
@@ -22,8 +22,11 @@ const StatisticsController = (($) => {
      * Fetch statistics from the server and render results
      */
     const fetchStats = () => {
+        StatisticsView.showLoader();
+
         NetworkHelper.makeRequest("statistics", false, "GET").then(response => {
             view.renderStats(response);
+            StatisticsView.removeLoader();
         });
     }
 

--- a/src/main/resources/com/toptrumps/online/scripts/plugins/loader.js
+++ b/src/main/resources/com/toptrumps/online/scripts/plugins/loader.js
@@ -1,0 +1,48 @@
+/**
+ * Loader animation plugin
+ */
+
+const Loader = (($) => {
+    /** VARIABLES AND CONSTANTS */
+
+        // Selectors
+    const loaderSelector = ".js-loader";
+    const loaderTextSelector = ".js-loader-text";
+
+    // CSS classes to represent visual state
+    const openedModalClass = "loader--shown";
+    const activeLoaderBoxClass = "active-loader"
+
+    // Templates
+    const loaderTemplate = `<div class="loader js-loader">
+        <div class="loader__spinner"></div>
+        <span class="js-loader-text">Loading...</span>
+    </div>`;
+
+
+    /** METHODS */
+
+    /**
+     * Shows loader
+     */
+    const showLoader = ($targetBox, text) => {
+        $targetBox.addClass(activeLoaderBoxClass);
+        $(document.body).append(loaderTemplate);
+        $(loaderTextSelector).text(text);
+    };
+
+    /**
+     * Removes loader
+     */
+    const removeLoader = $targetBox => {
+        $targetBox.removeClass(activeLoaderBoxClass);
+        $(loaderSelector).remove();
+    };
+
+    /** EXPOSE PUBLIC METHODS **/
+
+    return {
+        removeLoader,
+        showLoader,
+    }
+})(jQuery);

--- a/src/main/resources/com/toptrumps/online/scripts/views/GameView.js
+++ b/src/main/resources/com/toptrumps/online/scripts/views/GameView.js
@@ -27,6 +27,7 @@ const GameView = (($) => {
     const gameOverRoundsWrapperSelector = ".js-game-over-rounds-wrapper";
     const gameOverRoundsName = ".js-game-over-rounds-name";
     const gameOverRoundsNumber = ".js-game-over-rounds-number";
+    const gameBox = ".js-game-box";
 
     // Modals
     const modalSelectors = {
@@ -606,6 +607,22 @@ const GameView = (($) => {
         Modal.closeActiveModal();
     };
 
+    /**
+     * Show loader for statistics box
+     */
+    const showLoader = () => {
+        const $target = $(gameBox);
+        Loader.showLoader($target, "Saving statistics. Please wait...");
+    };
+
+    /**
+     * Removes active loader
+     */
+    const removeLoader = () => {
+        const $target = $(gameBox);
+        Loader.removeLoader($target);
+    };
+
 
     /** EXPOSE PUBLIC METHODS **/
 
@@ -622,12 +639,14 @@ const GameView = (($) => {
         enableAttributeSelection,
         getStatsMarkup,
         highlightAttribute,
+        removeLoader,
         renderPlayer,
         resetAttributeHighlight,
         resetCard,
         resetRound,
         setPlayerStateToDefeated,
         showCard,
+        showLoader,
         showMessage,
         showModal,
         showOpponentsCards,

--- a/src/main/resources/com/toptrumps/online/scripts/views/GameView.js
+++ b/src/main/resources/com/toptrumps/online/scripts/views/GameView.js
@@ -480,12 +480,15 @@ const GameView = (($) => {
      * @param cardsOnTable - array with all cards currently in play
      */
     const showOpponentsCards = cardsOnTable => {
-        cardsOnTable.forEach(async (data, index) => {
+        cardsOnTable.forEach((data, index) => {
             if (data.playerID === 0) return; // skip human player's card
 
-            await delay((timerBase / 2) * index);
-
-            showCard(data.playerID, data.card);
+            // For each loops work unstable with promises
+            // Switch to default timeouts, as it does not
+            // affect gameplay
+            setTimeout(() => {
+                showCard(data.playerID, data.card);
+            }, (timerBase / 2) * index);
         });
     };
 

--- a/src/main/resources/com/toptrumps/online/scripts/views/StatisticsView.js
+++ b/src/main/resources/com/toptrumps/online/scripts/views/StatisticsView.js
@@ -4,6 +4,7 @@
 
 const StatisticsView = (($) => {
     /** VARIABLES AND CONSTANTS */
+    const statsPage = ".js-statistics-box";
     const statsGamesPlayedSelector = ".js-stats-games-played-value";
     const statsAIWinsSelector = ".js-stats-ai-wins-value";
     const statsHumanWinsSelector = ".js-stats-human-wins-value";
@@ -119,9 +120,27 @@ const StatisticsView = (($) => {
         Modal.openModal(targetModalSelector, title, hint);
     };
 
+    /**
+     * Show loader for statistics box
+     */
+    const showLoader = () => {
+        const $target = $(statsPage);
+        Loader.showLoader($target, "Loading statistics. Please wait...");
+    };
+
+    /**
+     * Removes active loader
+     */
+    const removeLoader = () => {
+        const $target = $(statsPage);
+        Loader.removeLoader($target);
+    };
+
     /** EXPOSE PUBLIC METHODS **/
     return {
         init,
+        removeLoader,
         renderStats,
+        showLoader,
     }
 })(jQuery);

--- a/src/main/resources/com/toptrumps/online/styles/game-screen.css
+++ b/src/main/resources/com/toptrumps/online/styles/game-screen.css
@@ -228,7 +228,6 @@
 @-webkit-keyframes active-player-animation {
     from {
         box-shadow: none;
-        /*box-shadow: 0 0 5px var(--color-animation-active), 0 0 10px var(--color-animation-active), 0 0 15px var(--color-animation-active), 0 0 20px var(--color-animation-active), 0 0 35px var(--color-animation-active), 0 0 40px var(--color-animation-active), 0 0 50px var(--color-animation-active), 0 0 75px var(--color-animation-active);*/
     }
     to {
         box-shadow: 0 0 3px var(--color-animation-active),
@@ -245,7 +244,6 @@
 @-webkit-keyframes human-player-animation {
     from {
         box-shadow: none;
-        /*box-shadow: 0 0 5px var(--color-animation-winner), 0 0 10px var(--color-animation-winner), 0 0 15px var(--color-animation-winner), 0 0 20px var(--color-animation-winner), 0 0 35px var(--color-animation-winner), 0 0 40px var(--color-animation-winner), 0 0 50px var(--color-animation-winner), 0 0 75px var(--color-animation-winner);*/
     }
     to {
         box-shadow: 0 0 3px var(--color-animation-human),
@@ -262,7 +260,6 @@
 @-webkit-keyframes winner-player-animation {
     from {
         box-shadow: none;
-        /*box-shadow: 0 0 5px var(--color-animation-winner), 0 0 10px var(--color-animation-winner), 0 0 15px var(--color-animation-winner), 0 0 20px var(--color-animation-winner), 0 0 35px var(--color-animation-winner), 0 0 40px var(--color-animation-winner), 0 0 50px var(--color-animation-winner), 0 0 75px var(--color-animation-winner);*/
     }
     to {
         box-shadow: 0 0 3px #fff,
@@ -340,10 +337,6 @@
 .pcard__front {
     background: #38302a;
     border-color: #626767;
-}
-
-.human-player .pcard {
-    /* transform: scale(1.3) translateY(-4rem); */
 }
 
 .countdown {

--- a/src/main/resources/com/toptrumps/online/styles/global.css
+++ b/src/main/resources/com/toptrumps/online/styles/global.css
@@ -91,3 +91,64 @@ body {
     font-size: 1.6rem;
     font-weight: bold;
 }
+
+.loader {
+    position: absolute;
+    width: 20rem;
+    height: 8rem;
+    z-index: 50;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    padding-top: 12rem;
+}
+
+.loader__spinner,
+.loader__spinner:after {
+    border-radius: 50%;
+    width: 10rem;
+    height: 10rem;
+}
+
+.loader__spinner {
+    font-size: 1rem;
+    position: absolute;
+    top: 0;
+    left: 50%;
+    margin-left: -5rem;
+    border-top: 1rem solid rgba(255, 255, 255, 0.2);
+    border-right: 1rem solid rgba(255, 255, 255, 0.2);
+    border-bottom: 1rem solid rgba(255, 255, 255, 0.2);
+    border-left: 1rem solid #ffffff;
+    box-sizing: border-box;
+    animation: loader 1.1s infinite linear;
+}
+
+.active-loader {
+    position: relative;
+}
+
+.active-loader::before {
+    display: block;
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, .7);
+    z-index: 40;
+    pointer-events: none;
+}
+
+@keyframes loader {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform: rotate(360deg);
+    }
+}

--- a/src/main/resources/com/toptrumps/online/views/GameScreen.ftl
+++ b/src/main/resources/com/toptrumps/online/views/GameScreen.ftl
@@ -2,7 +2,7 @@
 
 	<div class="js-page-curtain page-curtain"></div>
 
-	<main class="game-page">
+	<main class="game-page js-game-box">
 		<div class="draw-indicator">Draw!</div>
 		<#include "_parts/GameStatus.ftl">
 		<#include "_parts/Opponents.ftl">
@@ -22,6 +22,7 @@
 	<script src="/assets/scripts/libs/jquery-3.4.1.min.js"></script>
 	<script src="/assets/scripts/libs/anime.min.js"></script>
 	<script src="/assets/scripts/config/settings.js"></script>
+	<script src="/assets/scripts/plugins/loader.js"></script>
 	<script src="/assets/scripts/plugins/screen.js"></script>
 	<script src="/assets/scripts/helpers/network.js"></script>
 	<script src="/assets/scripts/plugins/message.js"></script>

--- a/src/main/resources/com/toptrumps/online/views/Statistics.ftl
+++ b/src/main/resources/com/toptrumps/online/views/Statistics.ftl
@@ -1,6 +1,6 @@
 <#include "_parts/Header.ftl">
 
-	<main class="statistics-page">
+	<main class="statistics-page js-statistics-box">
 		<div class="statistics-page-top-panel">
 			<a href="/toptrumps/" class="button button--outlined">Go back</a>
 			<h1 class="game-title">Statistics</h1>
@@ -64,6 +64,7 @@
 	<script src="/assets/scripts/libs/jquery-3.4.1.min.js"></script>
 	<script src="/assets/scripts/config/settings.js"></script>
 	<script src="/assets/scripts/helpers/network.js"></script>
+	<script src="/assets/scripts/plugins/loader.js"></script>
 	<script src="/assets/scripts/plugins/screen.js"></script>
 	<script src="/assets/scripts/plugins/modal.js"></script>
 	<script src="/assets/scripts/plugins/input-number.js"></script>


### PR DESCRIPTION
This PR:
- adds loader for end game statistics and statistics screen
- changes the order of end game checks

<img width="753" alt="Screenshot 2020-02-16 at 14 31 37" src="https://user-images.githubusercontent.com/288069/74606527-12116580-50c9-11ea-9756-132bda043128.png">

<img width="756" alt="Screenshot 2020-02-16 at 14 31 27" src="https://user-images.githubusercontent.com/288069/74606528-163d8300-50c9-11ea-92a5-7220d43488d1.png">
